### PR TITLE
Adding Vagrant for simple dev setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -65,3 +65,5 @@ application
 logs
 src/server/yellr-serv/uploads/*
 src/server/yellr-serv/*.sqlite
+
+.vagrant

--- a/README.md
+++ b/README.md
@@ -74,6 +74,17 @@ yellr/
 (virtualenv)$ pserve development.ini
 ```
 
+#### Create your VM
+Alternative to creating a virtualenv, you can spin up a Vagrant VM
+
+```
+vagrant up
+vagrant ssh
+cd /cd server/yellr-serv
+pserve development.ini
+# navigate to http://192.168.50.100:5000/ on your host
+```
+
 
 
 

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,23 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.provider "virtualbox" do |vb, override|
+    override.vm.box = "box-cutter/fedora20"
+  end
+
+  config.vm.define "web" do |api|
+    api.vm.synced_folder "src/server", "/home/vagrant/server"
+    api.vm.network "private_network", ip: "192.168.50.100"
+  end
+
+  config.vm.provision "ansible", run: "always" do |ansible|
+    ansible.groups = {
+      "web" => ["web"],
+    }
+    ansible.playbook = "vagrant-setup/vagrant.yml"
+  end
+end

--- a/vagrant-setup/roles/base-dev/tasks/main.yml
+++ b/vagrant-setup/roles/base-dev/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: install required packages
+  yum: name={{ item }} state=latest
+  with_items:
+    - python-pip
+
+- name: install python packages
+  pip: name={{ item }} state=latest
+  with_items:
+    - mutagen
+    - pyramid
+    - pyramid_chameleon
+    - pyramid_debugtoolbar
+    - pyramid_tm
+    - python-magic
+    - SQLAlchemy
+    - transaction
+    - zope.sqlalchemy
+    - waitress
+
+- name: install yellr
+  shell: python setup.py develop && initialize_yellr-serv_db development.ini
+  args:
+    chdir: /home/vagrant/server/yellr-serv

--- a/vagrant-setup/vagrant.yml
+++ b/vagrant-setup/vagrant.yml
@@ -1,0 +1,8 @@
+---
+- name: web deployment
+  hosts: web
+  sudo: yes
+  vars:
+    env: dev
+  roles:
+    - base-dev


### PR DESCRIPTION
Hey Yellrs, I added a Vagrant setup to help me learn the structure of this application while y'all were figuring out what needed to be done during the Hackathon. This removes the need to

Assuming you have Vagrant, VirtualBox, and Ansible installed (you van get these with brew), just run

```
vagrant up
vagrant ssh
cd /cd server/yellr-serv
pserve development.ini
# navigate to http://192.168.50.100:5000/ on your host
```

I can also get some nice automation going to apply this to the actual server hosting the real application based off the same stuff.
